### PR TITLE
T3ENCBE106 refactoring pagerenderer

### DIFF
--- a/Classes/Factory/FeatureFactory.php
+++ b/Classes/Factory/FeatureFactory.php
@@ -6,13 +6,12 @@ namespace DMF\EnhancedBackend\Factory;
 
 use DMF\EnhancedBackend\Model\Feature;
 use DMF\EnhancedBackend\Model\Group;
-use DMF\EnhancedBackend\Service\BackendUserService;
+use DMF\EnhancedBackend\Service\FeatureService;
 use TYPO3\CMS\Core\Configuration\Loader\YamlFileLoader;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /**
+ * Generates Feature models based on user settings and configuration
  *
  * This file is part of a 3m5. Extension for TYPO3 CMS.
  *
@@ -22,18 +21,8 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
  *  (c) 2023 3m5. Media GmbH <jan.suchandt@3m5.de>
  *
  **/
-
-
-
-/**
- * Generates Feature models based on user settings and configuration
- */
 class FeatureFactory
 {
-    public function __construct() {
-
-    }
-
     /**
      * @return void
      */
@@ -55,7 +44,7 @@ class FeatureFactory
                     foreach ($featuresConfig as $featureConfig) {
                         // TODO add to construct
                         $feature = new Feature();
-                        $featureId = BackendUserService::FIELD_NAME_PREFIX . '-' . $groupId . '__' . $featureConfig['id'];
+                        $featureId = FeatureService::FIELD_NAME_PREFIX . '-' . $groupId . '__' . $featureConfig['id'];
                         $feature->setId($featureId);
                         $feature->setGroup($group);
                         $feature->setTitle($featureConfig['title']);
@@ -67,7 +56,6 @@ class FeatureFactory
                 }
             }
         }
-
         return $features;
     }
 
@@ -78,7 +66,7 @@ class FeatureFactory
      */
     private function getConfigByYaml():array {
         $yamlFileLoader = GeneralUtility::makeInstance(YamlFileLoader::class);
-        return $yamlFileLoader->load(BackendUserService::YAML_CONFIG_FILE);
+        return $yamlFileLoader->load(FeatureService::YAML_CONFIG_FILE);
     }
 
 }

--- a/Classes/Service/BackendUserService.php
+++ b/Classes/Service/BackendUserService.php
@@ -27,7 +27,8 @@ class BackendUserService implements SingletonInterface
 
     protected array $userSettings = [];
 
-    public function __construct(LoggerInterface $logger) {
+    public function __construct(LoggerInterface $logger)
+    {
         $this->logger = $logger;
     }
 
@@ -67,37 +68,13 @@ class BackendUserService implements SingletonInterface
     }
 
     /**
-     * Get all active features by user settings of backend user for EnBa
-     *
-     * @return array
-     */
-    /**
-    public function getFeatureSettings(): array
-    {
-        $allBeUserSettings = $this->getBackendUserSettings();
-        if (!$allBeUserSettings || count($allBeUserSettings) === 0) {
-            return [];
-        }
-
-        $featureSettings = [];
-        foreach ($allBeUserSettings as $userSettingIdentifier => $userSetting) {
-            if (!$this->isEnbaUserSettingById($userSettingIdentifier)) {
-                $featureSettings[$userSettingIdentifier] = $userSetting;
-            }
-        }
-
-        return $featureSettings;
-    }
-     */
-
-    /**
      * Get all backend user settings
      *
      * @return array|null
      */
     public function getBackendUserSettings(): ?array
     {
-        if(count($this->userSettings) > 0) {
+        if (count($this->userSettings) > 0) {
             return $this->userSettings;
         }
 
@@ -105,8 +82,8 @@ class BackendUserService implements SingletonInterface
             $this->logger->warning('Try to get user settings without existing backend user');
             return [];
         }
-        if(!$GLOBALS['BE_USER']->uc) {
-            $this->logger->warning('Try to get user settings without existing backend user');
+        if (!$GLOBALS['BE_USER']->uc) {
+            $this->logger->warning('Current backend user does not have any user settings in his UC');
             return [];
         }
         $this->userSettings = $GLOBALS['BE_USER']->uc;
@@ -120,7 +97,5 @@ class BackendUserService implements SingletonInterface
     {
         return $GLOBALS['BE_USER'] instanceof BackendUserAuthentication;
     }
-
-
 
 }

--- a/Classes/Service/FeatureService.php
+++ b/Classes/Service/FeatureService.php
@@ -24,7 +24,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Managing features collected by configuration and user settings
  */
-class FeatureService implements SingletonInterface {
+class FeatureService implements SingletonInterface
+{
     public const FIELD_NAME_PREFIX = 'enba';
     public const YAML_CONFIG_FILE = 'EXT:enhanced-backend/Configuration/Yaml/Features.yaml';
 
@@ -66,20 +67,21 @@ class FeatureService implements SingletonInterface {
     /**
      * @return void
      */
-    private function setActiveFeaturesByBackendUserSettings(): void {
-        if(count($this->features) === 0) {
+    private function setActiveFeaturesByBackendUserSettings(): void
+    {
+        if (count($this->features) === 0) {
             $this->logger->debug('No Enba features available or not set');
             return;
         }
 
         $backendUserService = $this->getBackendUserService();
         $userSettings = $backendUserService->getBackendUserSettings();
-        if(count($userSettings) === 0) {
+        if (count($userSettings) === 0) {
             $this->logger->warning('Try to set active feature without backend user or user settings');
             return;
         }
         foreach ($userSettings as $userSettingId => $userSettingValue) {
-            if(!BackendUserService::isEnBaUserSettingById($userSettingId)) {
+            if (!BackendUserService::isEnBaUserSettingById($userSettingId)) {
                 $this->logger->debug('UserSetting is not a enba-setting', [
                     'userSettingId' => $userSettingId,
                     'userSettingValue' => $userSettingValue,
@@ -187,8 +189,9 @@ class FeatureService implements SingletonInterface {
     /**
      * @return BackendUserService
      */
-    private function getBackendUserService():BackendUserService {
-        if(!$this->backendUserService) {
+    private function getBackendUserService(): BackendUserService
+    {
+        if (!$this->backendUserService) {
             $this->backendUserService = GeneralUtility::makeInstance(BackendUserService::class);
         }
         return $this->backendUserService;

--- a/Classes/Utility/BackendUtility.php
+++ b/Classes/Utility/BackendUtility.php
@@ -29,7 +29,8 @@ class BackendUtility
      *
      * @return bool
      */
-    static function isBackendRequest():bool {
+    static function isBackendRequest(): bool
+    {
         $currentVersionNumber = self::getCurrentTypo3VersionNumberInt();
         if ($currentVersionNumber >= 11000000) {
             return ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend();
@@ -40,11 +41,13 @@ class BackendUtility
     /**
      * @return bool
      */
-    static function isCliRequest():bool {
+    static function isCliRequest(): bool
+    {
         return Environment::isCli();
     }
 
-    static function getCurrentTypo3VersionNumberInt():int {
+    static function getCurrentTypo3VersionNumberInt(): int
+    {
         return VersionNumberUtility::convertVersionNumberToInteger(VersionNumberUtility::getCurrentTypo3Version());
     }
 }

--- a/Classes/Utility/BackendUtility.php
+++ b/Classes/Utility/BackendUtility.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace DMF\EnhancedBackend\Utility;
 
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
+ * Different utility functions for backend, like version comparison
  *
  * This file is part of a 3m5. Extension for TYPO3 CMS.
  *
@@ -17,10 +19,6 @@ use TYPO3\CMS\Core\Utility\VersionNumberUtility;
  *  (c) 2023 3m5. Media GmbH <jan.suchandt@3m5.de>
  *
  **/
-
-/**
- *
- */
 class BackendUtility
 {
     /**
@@ -37,6 +35,13 @@ class BackendUtility
             return ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend();
         }
         return false;
+    }
+
+    /**
+     * @return bool
+     */
+    static function isCliRequest():bool {
+        return Environment::isCli();
     }
 
     static function getCurrentTypo3VersionNumberInt():int {

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -8,3 +8,9 @@ services:
   DMF\EnhancedBackend\Service\BackendUserService:
     public: true
 
+  DMF\EnhancedBackend\Service\BackendStyles:
+    public: true
+
+  DMF\EnhancedBackend\Service\FeatureService:
+    public: true
+

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -8,9 +8,11 @@ defined('TYPO3') || die();
 
 (function () {
     // Extend user settings
-    $backendUserService = GeneralUtility::makeInstance(BackendUserService::class);
-    $backendUserService->addFieldsToUserSettings();
+    GeneralUtility::makeInstance(BackendUserService::class)->addFieldsToUserSettings();
 
-    // Add frontend files and body classes
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][] = BackendStyles::class . '->addEnBaFrontendFiles';
+    // Add frontend files (javascript, stylesheet)
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][1678082377] = BackendStyles::class . '->addEnBaFrontendFiles';
+
+    // Add css classes to doc root html element
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['renderPostProcess'][1651606722] = BackendStyles::class . '->addEnBaCssClasses';
 })();


### PR DESCRIPTION
### Replace page renderer with renderPostProcess hook

Instead of using the page renderer for every request, we use the
more specific hook for backend layouts. Drawback: css classes applied
to root html only.

Refactored services to be more clear in use, add types and logging.